### PR TITLE
Swift3

### DIFF
--- a/Sources/Emoji.swift
+++ b/Sources/Emoji.swift
@@ -10,7 +10,7 @@ public final class Emoji : EmojiData {
     ///
     public static var SingleEmojiPattern:String = {
         // The "emoji" group needs to be followed by a special character to be rendered like emoji.
-        let emojiVariants = "(?:(?:\(EmojiPatterns.joinWithSeparator("|")))\\uFE0F)"
+        let emojiVariants = "(?:(?:\(EmojiPatterns.joinWithSeparator("|")))\\uFE0F{0,1})"
         
         // Emoji can be followed by optional combining marks. The standard says only keycaps and
         // backslash are likely to be supported.

--- a/Sources/Emoji.swift
+++ b/Sources/Emoji.swift
@@ -10,19 +10,19 @@ public final class Emoji : EmojiData {
     ///
     public static var SingleEmojiPattern:String = {
         // The "emoji" group needs to be followed by a special character to be rendered like emoji.
-        let emojiVariants = "(?:(?:\(EmojiPatterns.joinWithSeparator("|")))\\uFE0F{0,1})"
+        let emojiVariants = "(?:(?:\(EmojiPatterns.joined(separator: "|")))\\uFE0F{0,1})"
         
         // Emoji can be followed by optional combining marks. The standard says only keycaps and
         // backslash are likely to be supported.
         let combiningMarks = "[\\u20E3\\u20E0]"
         
         // "Presentation" characters are rendered as emoji by default and need no variant.
-        let emojiPresentation = "\(EmojiPresentationPatterns.joinWithSeparator("|"))"
+        let emojiPresentation = "\(EmojiPresentationPatterns.joined(separator: "|"))"
         
         // Some other emoji are sequences of characters, joined with 'Zero Width Joiner' characters.
         // We want the longest match, so we sort these in reverse order.
-        let zwjSequences = ZWJSequencePatterns.reverse().joinWithSeparator("|")
-        let otherSequences = SequencePatterns.joinWithSeparator("|")
+        let zwjSequences = ZWJSequencePatterns.reversed().joined(separator: "|")
+        let otherSequences = SequencePatterns.joined(separator: "|")
         
         return "(?:(?:\(zwjSequences)|\(otherSequences)|\(emojiVariants)|\(emojiPresentation))\(combiningMarks)?)"
     }()
@@ -81,9 +81,9 @@ public final class Emoji : EmojiData {
     /// Returns `true` if the given string is composed solely of emoji and (optional) whitespace.
     /// Empty or blank strings will not match.
     ///
-    public static func isPureEmojiString(string:String) -> Bool {
+    public static func isPureEmojiString(_ string:String) -> Bool {
         let range = NSRange(location: 0, length: string.utf16.count)
-        let firstMatch = PureEmojiAndWhitespaceRegex.rangeOfFirstMatchInString(string, options:[], range:range)
+        let firstMatch = PureEmojiAndWhitespaceRegex.rangeOfFirstMatch(in: string, options:[], range:range)
         return firstMatch.location != NSNotFound
     }
     

--- a/Sources/EmojiData.swift
+++ b/Sources/EmojiData.swift
@@ -10,9 +10,9 @@
 ///
 ///   http://www.unicode.org/Public/emoji/2.0/
 ///
-public class EmojiData {
+open class EmojiData {
     
-    public static let EmojiPatterns:[String] = [
+    open static let EmojiPatterns:[String] = [
         "\\u0023",    // [1] (#️)      NUMBER SIGN
         "\\u002A",    // [1] (*)       ASTERISK
         "[\\u0030-\\u0039]",    // [10] (0️..9️)  DIGIT ZERO..DIGIT NINE
@@ -154,7 +154,7 @@ public class EmojiData {
         "\\u3299"     // [1] (㊙️)      CIRCLED IDEOGRAPH SECRET
     ]
 
-    public static let EmojiPresentationPatterns:[String] = [
+    open static let EmojiPresentationPatterns:[String] = [
         "\\U0001F004",    // [1] (🀄️)      MAHJONG TILE RED DRAGON
         "\\U0001F0CF",    // [1] (🃏)       PLAYING CARD BLACK JOKER
         "\\U0001F18E",    // [1] (🆎)       NEGATIVE SQUARED AB
@@ -224,11 +224,11 @@ public class EmojiData {
         "\\u2B55"     // [1] (⭕️)      HEAVY LARGE CIRCLE
     ]
   
-    public static let ModifierPatterns:[String] = [
+    open static let ModifierPatterns:[String] = [
         "[\\U0001F3FB-\\U0001F3FF]"     // [5] (🏻..🏿)    EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
     ]
   
-    public static let ModifierBasePatterns:[String] = [
+    open static let ModifierBasePatterns:[String] = [
         "\\U0001F385",    // [1] (🎅)       FATHER CHRISTMAS
         "[\\U0001F3C3-\\U0001F3C4]",    // [2] (🏃..🏄)    RUNNER..SURFER
         "[\\U0001F3CA-\\U0001F3CB]",    // [2] (🏊..🏋)    SWIMMER..WEIGHT LIFTER
@@ -255,7 +255,7 @@ public class EmojiData {
         "[\\u270A-\\u270D]"     // [4] (✊..✍)    RAISED FIST..WRITING HAND
     ]
     
-    public static let SequencePatterns:[String] = [
+    open static let SequencePatterns:[String] = [
         "\\u0023\\u20E3",    // (#️⃣) keycap number sign
         "\\u002A\\u20E3",    // (*⃣) keycap asterisk
         "\\u0030\\u20E3",    // (0️⃣) keycap digit zero
@@ -847,7 +847,7 @@ public class EmojiData {
         "\\u270D\\U0001F3FF"     // (✍🏿) writing hand type-6
     ]
 
-    public static let ZWJSequencePatterns:[String] = [
+    open static let ZWJSequencePatterns:[String] = [
         "\\U0001F441\\u200D\\U0001F5E8",    // (👁‍🗨) eye, zwj, left speech bubble
         "\\U0001F468\\u200D\\U0001F468\\u200D\\U0001F466",    // (👨‍👨‍👦) man, zwj, man, zwj, boy
         "\\U0001F468\\u200D\\U0001F468\\u200D\\U0001F466\\u200D\\U0001F466",    // (👨‍👨‍👦‍👦) man, zwj, man, zwj, boy, zwj, boy

--- a/SwiftEmoji.xcodeproj/project.pbxproj
+++ b/SwiftEmoji.xcodeproj/project.pbxproj
@@ -212,7 +212,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Christian Niles";
 				TargetAttributes = {
 					6268929D1CCE9C6F00F3F6AD = {
@@ -324,8 +324,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -372,8 +374,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -393,6 +397,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -402,6 +407,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -424,6 +430,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -468,7 +475,7 @@
 		626892C21CCEA37000F3F6AD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -481,7 +488,7 @@
 				PRODUCT_NAME = SwiftEmoji;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -489,7 +496,7 @@
 		626892C31CCEA37000F3F6AD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -502,7 +509,7 @@
 				PRODUCT_NAME = SwiftEmoji;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-OSX.xcscheme
+++ b/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-iOS.xcscheme
+++ b/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Swift 3 conversion performed as part of the Xcode 8 update of an app I'm technical lead on.

The head of the swift3 fork does contain an additional commit making the special character following an emoji group optional. The original regex was not consistently detecting emojis, with certain characters not being reported despite being in the data file. This is probably due more to the string with the emoji was being generated (saving the text from a text field) not adhering to that requirement
