### PR TITLE
Swift 3: fixes, recommended project settings

### DIFF
--- a/Sources/EmojiData.swift
+++ b/Sources/EmojiData.swift
@@ -10,14 +10,14 @@
 ///
 ///   http://www.unicode.org/Public/emoji/3.0/
 ///
-public class EmojiData {
+open class EmojiData {
     
     ///
     /// Patterns that match characters in the "Emoji" group. Note that characters in this group are
     /// (confusingly) not rendered as Emoji by default. They must be followed by the U+FE0F (variant
     /// selector) character to be rendered as Emoji.
     /// 
-    public static let EmojiPatterns:[String] = [
+    open static let EmojiPatterns:[String] = [
         "\\u0023",    // 1.1  [1] (#)       NUMBER SIGN
         "\\u002A",    // 1.1  [1] (*)       ASTERISK
         "[\\u0030-\\u0039]",    // 1.1 [10] (0..9)    DIGIT ZERO..DIGIT NINE
@@ -233,7 +233,7 @@ public class EmojiData {
     /// Patterns that match characters in the "Emoji Presentation" group. These characters are
     /// rendered as Emoji by default, and do not need a variant selector, unlike `EmojiPatterns`.
     ///
-    public static let EmojiPresentationPatterns:[String] = [
+    open static let EmojiPresentationPatterns:[String] = [
         "\\U0001F004",    // 5.1  [1] (🀄)       MAHJONG TILE RED DRAGON
         "\\U0001F0CF",    // 6.0  [1] (🃏)       PLAYING CARD BLACK JOKER
         "\\U0001F18E",    // 6.0  [1] (🆎)       NEGATIVE SQUARED AB
@@ -353,7 +353,7 @@ public class EmojiData {
     /// Patterns that match "Emoji_Modifier_Base" characters, which are those that can be modified
     /// by "Emoji_Modifier" (skintone) characters.
     ///
-    public static let ModifierBasePatterns:[String] = [
+    open static let ModifierBasePatterns:[String] = [
         "\\U0001F385",    // 6.0  [1] (🎅)       FATHER CHRISTMAS
         "[\\U0001F3C3-\\U0001F3C4]",    // 6.0  [2] (🏃..🏄)    RUNNER..SURFER
         "\\U0001F3CA",    // 6.0  [1] (🏊)       SWIMMER
@@ -392,7 +392,7 @@ public class EmojiData {
     /// Patterns that match "Emoji_Modifier" characters (Skin Tones, aka. Fitzpatrick Modifiers).
     /// These modifiers follow the characters in the "Emoji_Modifier_Base" group.
     ///
-    public static let ModifierPatterns:[String] = [
+    open static let ModifierPatterns:[String] = [
         "[\\U0001F3FB-\\U0001F3FF]"     // 8.0  [5] (🏻..🏿)    EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
     ]
     
@@ -401,7 +401,7 @@ public class EmojiData {
     /// variants, but not Zero-Width-Joiner (ZWJ) sequences used for "family" characters like
     /// "👨‍👩‍👧‍👧".
     ///
-    public static let SequencePatterns:[String] = [
+    open static let SequencePatterns:[String] = [
         "\\u0023\\uFE0F\\u20E3",    // 3.0  [1] (#️⃣)      Keycap NUMBER SIGN
         "\\u002A\\uFE0F\\u20E3",    // 3.0  [1] (*️⃣)      Keycap ASTERISK
         "\\u0030\\uFE0F\\u20E3",    // 3.0  [1] (0️⃣)      Keycap DIGIT ZERO
@@ -1092,7 +1092,7 @@ public class EmojiData {
     /// Patterns that match Zero-Width-Joiner (ZWJ) sequences used for "family" characters like
     /// "👨‍👩‍👧‍👧".
     ///
-    public static let ZWJSequencePatterns:[String] = [
+    open static let ZWJSequencePatterns:[String] = [
         "\\U0001F441\\u200D\\U0001F5E8",    // 7.0  [1] (👁‍🗨)      EYE, LEFT SPEECH BUBBLE
         "\\U0001F468\\u200D\\U0001F468\\u200D\\U0001F466",    // 6.0  [1] (👨‍👨‍👦)     Family: MAN, MAN, BOY
         "\\U0001F468\\u200D\\U0001F468\\u200D\\U0001F466\\u200D\\U0001F466",    // 6.0  [1] (👨‍👨‍👦‍👦)    Family: MAN, MAN, BOY, BOY

--- a/SwiftEmoji.xcodeproj/project.pbxproj
+++ b/SwiftEmoji.xcodeproj/project.pbxproj
@@ -212,7 +212,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Christian Niles";
 				TargetAttributes = {
 					6268929D1CCE9C6F00F3F6AD = {
@@ -324,8 +324,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -372,8 +374,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -393,6 +397,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -402,6 +407,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -424,6 +430,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -468,7 +475,7 @@
 		626892C21CCEA37000F3F6AD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 3;
@@ -481,7 +488,7 @@
 				PRODUCT_NAME = SwiftEmoji;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -489,7 +496,7 @@
 		626892C31CCEA37000F3F6AD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 3;
@@ -502,7 +509,7 @@
 				PRODUCT_NAME = SwiftEmoji;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-OSX.xcscheme
+++ b/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-iOS.xcscheme
+++ b/SwiftEmoji.xcodeproj/xcshareddata/xcschemes/SwiftEmoji-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Hey!

I've noticed, that https://github.com/nerdyc/SwiftEmoji/pull/1 wasn't complete - in few places, `SWIFT_VERSION` was kept as `2.3`. Also, I've run Xcode code migrator and applied recommended project settings - now everything builds without errors and warnings on Xcode 8.0.

I'd also suggest to maybe tag and release current `master`, as one with working support for Swift 3 - it's easier to use with Carthage (point to version vs. point to branch).

EDIT: sorry for a typo in commit message. 😭 